### PR TITLE
LPS-45660 StaleObjectStateException when LDAP Export and email verification is turned on

### DIFF
--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/portlet/action/FacebookConnectAction.java
@@ -172,10 +172,11 @@ public class FacebookConnectAction extends BaseStrutsAction {
 		user = _userLocalService.updateLastLogin(
 			user.getUserId(), user.getLoginIP());
 
-		user = _userLocalService.updatePasswordReset(user.getUserId(), false);
+		_userLocalService.updatePasswordReset(user.getUserId(), false);
 
-		user = _userLocalService.updateEmailAddressVerified(
-			user.getUserId(), true);
+		_userLocalService.updateEmailAddressVerified(user.getUserId(), true);
+
+		user = _userLocalService.getUserById(companyId, user.getUserId());
 
 		session.setAttribute(WebKeys.FACEBOOK_USER_EMAIL_ADDRESS, emailAddress);
 

--- a/modules/portal-security/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/portlet/action/GoogleLoginAction.java
+++ b/modules/portal-security/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/portlet/action/GoogleLoginAction.java
@@ -180,10 +180,12 @@ public class GoogleLoginAction extends BaseStrutsAction {
 		user = _userLocalService.updateLastLogin(
 			user.getUserId(), user.getLoginIP());
 
-		user = _userLocalService.updatePasswordReset(user.getUserId(), false);
+		_userLocalService.updatePasswordReset(user.getUserId(), false);
 
-		user = _userLocalService.updateEmailAddressVerified(
+		_userLocalService.updateEmailAddressVerified(
 			user.getUserId(), true);
+
+		user = _userLocalService.getUserById(user.getUserId());
 
 		session.setAttribute(
 			GoogleWebKeys.GOOGLE_USER_EMAIL_ADDRESS, emailAddress);

--- a/portal-impl/src/com/liferay/portal/service/http/UserServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/UserServiceHttp.java
@@ -1607,9 +1607,9 @@ public class UserServiceHttp {
 		}
 	}
 
-	public static com.liferay.portal.model.User updatePassword(
-		HttpPrincipal httpPrincipal, long userId, java.lang.String password1,
-		java.lang.String password2, boolean passwordReset)
+	public static void updatePassword(HttpPrincipal httpPrincipal, long userId,
+		java.lang.String password1, java.lang.String password2,
+		boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(UserServiceUtil.class,
@@ -1618,10 +1618,8 @@ public class UserServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
 					password1, password2, passwordReset);
 
-			Object returnObj = null;
-
 			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
 			}
 			catch (Exception e) {
 				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
@@ -1630,8 +1628,6 @@ public class UserServiceHttp {
 
 				throw new com.liferay.portal.kernel.exception.SystemException(e);
 			}
-
-			return (com.liferay.portal.model.User)returnObj;
 		}
 		catch (com.liferay.portal.kernel.exception.SystemException se) {
 			_log.error(se, se);

--- a/portal-impl/src/com/liferay/portal/service/http/UserServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/UserServiceSoap.java
@@ -1371,14 +1371,12 @@ public class UserServiceSoap {
 	password the next time they log in
 	* @return the user
 	*/
-	public static com.liferay.portal.model.UserSoap updatePassword(
-		long userId, java.lang.String password1, java.lang.String password2,
-		boolean passwordReset) throws RemoteException {
+	public static void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
+		throws RemoteException {
 		try {
-			com.liferay.portal.model.User returnValue = UserServiceUtil.updatePassword(userId,
-					password1, password2, passwordReset);
-
-			return com.liferay.portal.model.UserSoap.toSoapModel(returnValue);
+			UserServiceUtil.updatePassword(userId, password1, password2,
+				passwordReset);
 		}
 		catch (Exception e) {
 			_log.error(e, e);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4695,13 +4695,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * @return the user
 	 */
 	@Override
-	public User updatePassword(
+	public void updatePassword(
 			long userId, String password1, String password2,
 			boolean passwordReset)
 		throws PortalException {
 
-		return updatePassword(
-			userId, password1, password2, passwordReset, false);
+		updatePassword(userId, password1, password2, passwordReset, false);
 	}
 
 	/**
@@ -4718,7 +4717,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * @return the user
 	 */
 	@Override
-	public User updatePassword(
+	public void updatePassword(
 			long userId, String password1, String password2,
 			boolean passwordReset, boolean silentUpdate)
 		throws PortalException {
@@ -4783,8 +4782,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		if (!silentUpdate) {
-			user.setPasswordModified(false);
-
 			passwordTrackerLocalService.trackPassword(userId, oldEncPwd);
 		}
 
@@ -4793,8 +4790,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				user, user.getCompanyId(), password1, null, null, null, null,
 				null, ServiceContextThreadLocal.getServiceContext());
 		}
-
-		return user;
 	}
 
 	/**
@@ -4810,7 +4805,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * @return the user
 	 */
 	@Override
-	public User updatePasswordManually(
+	public void updatePasswordManually(
 			long userId, String password, boolean passwordEncrypted,
 			boolean passwordReset, Date passwordModifiedDate)
 		throws PortalException {
@@ -4826,8 +4821,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setDigest(StringPool.BLANK);
 
 		userPersistence.update(user);
-
-		return user;
 	}
 
 	/**
@@ -4840,7 +4833,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 * @return the user
 	 */
 	@Override
-	public User updatePasswordReset(long userId, boolean passwordReset)
+	public void updatePasswordReset(long userId, boolean passwordReset)
 		throws PortalException {
 
 		User user = userPersistence.findByPrimaryKey(userId);
@@ -4848,8 +4841,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setPasswordReset(passwordReset);
 
 		userPersistence.update(user);
-
-		return user;
 	}
 
 	/**
@@ -5109,11 +5100,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		if (Validator.isNotNull(newPassword1) ||
 			Validator.isNotNull(newPassword2)) {
 
-			user = updatePassword(
-				userId, newPassword1, newPassword2, passwordReset);
+			updatePassword(
+				userId, newPassword1, newPassword2, passwordReset, false);
+
+			user = userPersistence.findByPrimaryKey(userId);
 
 			password = newPassword1;
 
+			user.setPasswordModified(false);
 			user.setDigest(StringPool.BLANK);
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -1505,7 +1505,7 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 	 * @return the user
 	 */
 	@Override
-	public User updatePassword(
+	public void updatePassword(
 			long userId, String password1, String password2,
 			boolean passwordReset)
 		throws PortalException {
@@ -1513,7 +1513,7 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 		UserPermissionUtil.check(
 			getPermissionChecker(), userId, ActionKeys.UPDATE);
 
-		return userLocalService.updatePassword(
+		userLocalService.updatePassword(
 			userId, password1, password2, passwordReset);
 	}
 

--- a/portal-service/src/com/liferay/portal/service/UserLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalService.java
@@ -2328,9 +2328,9 @@ public interface UserLocalService extends BaseLocalService,
 	password the next time they log in
 	* @return the user
 	*/
-	public com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset) throws PortalException;
+	public void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
+		throws PortalException;
 
 	/**
 	* Updates the user's password, optionally with tracking and validation of
@@ -2345,9 +2345,9 @@ public interface UserLocalService extends BaseLocalService,
 	tracked, or validated. Primarily used for password imports.
 	* @return the user
 	*/
-	public com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset, boolean silentUpdate) throws PortalException;
+	public void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset, boolean silentUpdate)
+		throws PortalException;
 
 	/**
 	* Updates the user's password with manually input information. This method
@@ -2361,10 +2361,9 @@ public interface UserLocalService extends BaseLocalService,
 	* @param passwordModifiedDate the new password modified date
 	* @return the user
 	*/
-	public com.liferay.portal.model.User updatePasswordManually(long userId,
-		java.lang.String password, boolean passwordEncrypted,
-		boolean passwordReset, java.util.Date passwordModifiedDate)
-		throws PortalException;
+	public void updatePasswordManually(long userId, java.lang.String password,
+		boolean passwordEncrypted, boolean passwordReset,
+		java.util.Date passwordModifiedDate) throws PortalException;
 
 	/**
 	* Updates whether the user should be asked to reset their password the next
@@ -2375,8 +2374,8 @@ public interface UserLocalService extends BaseLocalService,
 	password the next time they login
 	* @return the user
 	*/
-	public com.liferay.portal.model.User updatePasswordReset(long userId,
-		boolean passwordReset) throws PortalException;
+	public void updatePasswordReset(long userId, boolean passwordReset)
+		throws PortalException;
 
 	/**
 	* Updates the user's portrait image.

--- a/portal-service/src/com/liferay/portal/service/UserLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalServiceUtil.java
@@ -2796,12 +2796,10 @@ public class UserLocalServiceUtil {
 	password the next time they log in
 	* @return the user
 	*/
-	public static com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset)
+	public static void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .updatePassword(userId, password1, password2, passwordReset);
+		getService().updatePassword(userId, password1, password2, passwordReset);
 	}
 
 	/**
@@ -2817,12 +2815,11 @@ public class UserLocalServiceUtil {
 	tracked, or validated. Primarily used for password imports.
 	* @return the user
 	*/
-	public static com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset, boolean silentUpdate)
+	public static void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset, boolean silentUpdate)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .updatePassword(userId, password1, password2, passwordReset,
+		getService()
+			.updatePassword(userId, password1, password2, passwordReset,
 			silentUpdate);
 	}
 
@@ -2838,12 +2835,12 @@ public class UserLocalServiceUtil {
 	* @param passwordModifiedDate the new password modified date
 	* @return the user
 	*/
-	public static com.liferay.portal.model.User updatePasswordManually(
-		long userId, java.lang.String password, boolean passwordEncrypted,
+	public static void updatePasswordManually(long userId,
+		java.lang.String password, boolean passwordEncrypted,
 		boolean passwordReset, java.util.Date passwordModifiedDate)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .updatePasswordManually(userId, password, passwordEncrypted,
+		getService()
+			.updatePasswordManually(userId, password, passwordEncrypted,
 			passwordReset, passwordModifiedDate);
 	}
 
@@ -2856,10 +2853,9 @@ public class UserLocalServiceUtil {
 	password the next time they login
 	* @return the user
 	*/
-	public static com.liferay.portal.model.User updatePasswordReset(
-		long userId, boolean passwordReset)
+	public static void updatePasswordReset(long userId, boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().updatePasswordReset(userId, passwordReset);
+		getService().updatePasswordReset(userId, passwordReset);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalServiceWrapper.java
@@ -2970,11 +2970,10 @@ public class UserLocalServiceWrapper implements UserLocalService,
 	* @return the user
 	*/
 	@Override
-	public com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset)
+	public void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userLocalService.updatePassword(userId, password1, password2,
+		_userLocalService.updatePassword(userId, password1, password2,
 			passwordReset);
 	}
 
@@ -2992,11 +2991,10 @@ public class UserLocalServiceWrapper implements UserLocalService,
 	* @return the user
 	*/
 	@Override
-	public com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset, boolean silentUpdate)
+	public void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset, boolean silentUpdate)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userLocalService.updatePassword(userId, password1, password2,
+		_userLocalService.updatePassword(userId, password1, password2,
 			passwordReset, silentUpdate);
 	}
 
@@ -3013,11 +3011,11 @@ public class UserLocalServiceWrapper implements UserLocalService,
 	* @return the user
 	*/
 	@Override
-	public com.liferay.portal.model.User updatePasswordManually(long userId,
-		java.lang.String password, boolean passwordEncrypted,
-		boolean passwordReset, java.util.Date passwordModifiedDate)
+	public void updatePasswordManually(long userId, java.lang.String password,
+		boolean passwordEncrypted, boolean passwordReset,
+		java.util.Date passwordModifiedDate)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userLocalService.updatePasswordManually(userId, password,
+		_userLocalService.updatePasswordManually(userId, password,
 			passwordEncrypted, passwordReset, passwordModifiedDate);
 	}
 
@@ -3031,10 +3029,9 @@ public class UserLocalServiceWrapper implements UserLocalService,
 	* @return the user
 	*/
 	@Override
-	public com.liferay.portal.model.User updatePasswordReset(long userId,
-		boolean passwordReset)
+	public void updatePasswordReset(long userId, boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userLocalService.updatePasswordReset(userId, passwordReset);
+		_userLocalService.updatePasswordReset(userId, passwordReset);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserService.java
+++ b/portal-service/src/com/liferay/portal/service/UserService.java
@@ -818,9 +818,9 @@ public interface UserService extends BaseService {
 	password the next time they log in
 	* @return the user
 	*/
-	public com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset) throws PortalException;
+	public void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
+		throws PortalException;
 
 	/**
 	* Updates the user's portrait image.

--- a/portal-service/src/com/liferay/portal/service/UserServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserServiceUtil.java
@@ -947,12 +947,10 @@ public class UserServiceUtil {
 	password the next time they log in
 	* @return the user
 	*/
-	public static com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset)
+	public static void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .updatePassword(userId, password1, password2, passwordReset);
+		getService().updatePassword(userId, password1, password2, passwordReset);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserServiceWrapper.java
@@ -979,12 +979,10 @@ public class UserServiceWrapper implements UserService,
 	* @return the user
 	*/
 	@Override
-	public com.liferay.portal.model.User updatePassword(long userId,
-		java.lang.String password1, java.lang.String password2,
-		boolean passwordReset)
+	public void updatePassword(long userId, java.lang.String password1,
+		java.lang.String password2, boolean passwordReset)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userService.updatePassword(userId, password1, password2,
-			passwordReset);
+		_userService.updatePassword(userId, password1, password2, passwordReset);
 	}
 
 	/**


### PR DESCRIPTION
Hi @briangreenwald,

Based on Mike's last e-mail I'm sending the latest status of this fix. Unfortunately I was unable to test master for the error and the fix to see that it works fine. When I start to save a new user and export to LDAP is enabled, it never finishes the process.

I managed to catch until this call in WorkflowRegistryUtil:

```
 T updatedModel = workflowHandler.updateStatus(status, workflowContext);
```

But I'm stuck here.

Could you please take a look at it?

Regards,
Vilmos
